### PR TITLE
Feat/tc2023e-62 order published at

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -125,6 +125,7 @@
     "lucene-query-parser": "^1.2.0",
     "markdown-it": "^13.0.2",
     "markdown-it-emoji": "^2.0.2",
+    "markdown-it-meta": "^0.0.1",
     "markdown-table": "^1.1.1",
     "md5": "^2.2.1",
     "mermaid": "^10.1.0",

--- a/apps/app/src/server/routes/cms.ts
+++ b/apps/app/src/server/routes/cms.ts
@@ -1,5 +1,6 @@
-import md from 'markdown-it';
-import emoji from 'markdown-it-emoji';
+import MarkdownIt from 'markdown-it';
+import markdownItEmoji from 'markdown-it-emoji';
+import markdownItMeta from 'markdown-it-meta';
 
 import loggerFactory from '~/utils/logger';
 
@@ -62,7 +63,10 @@ module.exports = function(crowi) {
     });
 
     const pagesWithHTMLString = pagesSortedByPublishedAt.map((page) => {
-      return { page, htmlString: md({ html: true, linkify: true }).use(emoji).render(page.revision.body) };
+      const md = new MarkdownIt({ html: true, linkify: true });
+      md.use(markdownItMeta).use(markdownItEmoji);
+
+      return { page, htmlString: md.render(page.revision.body), frontMatter: md.meta.cms };
     });
 
     return res.json(ApiResponse.success(pagesWithHTMLString));
@@ -102,9 +106,10 @@ module.exports = function(crowi) {
       }
     }
 
-    const htmlString = md({ html: true, linkify: true }).use(emoji).render(page.revision.body);
+    const md = new MarkdownIt({ html: true, linkify: true });
+    md.use(markdownItMeta).use(markdownItEmoji);
 
-    return res.json(ApiResponse.success({ page, htmlString }));
+    return res.json(ApiResponse.success({ page, htmlString: md.render(page.revision.body), frontMatter: md.meta.cms }));
   };
 
   return actions;

--- a/apps/app/src/server/routes/cms.ts
+++ b/apps/app/src/server/routes/cms.ts
@@ -48,7 +48,20 @@ module.exports = function(crowi) {
       pages.pop();
     }
 
-    const pagesWithHTMLString = pages.map((page) => {
+    // TODO: filter と sort の処理を mongoDB のクエリ実行時に行う
+    // cmsMetadata に publishedAt が存在し、かつその日時が現在時刻以前のものを絞り込む
+    const filteredPages = pages.filter((page) => {
+      const publishedAt = page?.cmsMetadata?.get('publishedAt');
+      return publishedAt != null && new Date() > new Date(publishedAt);
+    });
+
+    const pagesSortedByPublishedAt = filteredPages.sort((a, b) => {
+      const timeA = new Date(a.cmsMetadata.get('publishedAt')).getTime();
+      const timeB = new Date(b.cmsMetadata.get('publishedAt')).getTime();
+      return timeB - timeA;
+    });
+
+    const pagesWithHTMLString = pagesSortedByPublishedAt.map((page) => {
       return { page, htmlString: md({ html: true, linkify: true }).use(emoji).render(page.revision.body) };
     });
 

--- a/apps/mobliz-clone/src/pages/[pageId].tsx
+++ b/apps/mobliz-clone/src/pages/[pageId].tsx
@@ -19,6 +19,7 @@ const DetailPage: NextPage<Props> = (props: Props) => {
   useEffect(() => {
     axios.get(`${process.env.NEXT_PUBLIC_APP_SITE_URL}/_cms/${pageId}.json`)
       .then((response) => {
+        console.log(response);
         setHTMLString(response.data.htmlString);
       })
       .catch((error) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9917,7 +9917,7 @@ js-string-escape@^1.0.1:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@^3.13.1:
+js-yaml@^3.13.1, js-yaml@^3.8.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -10640,6 +10640,13 @@ markdown-it-front-matter@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/markdown-it-front-matter/-/markdown-it-front-matter-0.2.3.tgz#d6fa0f4b362e02086dd4ce8219fadf3f4c9cfa37"
   integrity sha512-s9+rcClLmZsZc3YL8Awjg/YO/VdphlE20LJ9Bx5a8RAFLI5a1vq6Mll8kOzG6w/wy8yhFLBupaa6Mfd60GATkA==
+
+markdown-it-meta@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-meta/-/markdown-it-meta-0.0.1.tgz#d75b68f115659caf568e4ad43cb460a471248c39"
+  integrity sha512-sCQG7mHJM3i4l6MztgzxE8t3aTQB5CSCO0wq8k6CEaqud40eryWXqPesq5AyztbYgwnxJcNIsmFsKDRkrl6Zuw==
+  dependencies:
+    js-yaml "^3.8.1"
 
 markdown-it@^13.0.1:
   version "13.0.1"


### PR DESCRIPTION
## やったこと
- publishedAt でフィルタする
  - publishedAt が存在しないものは表示しない
  - publishedAt が現在時刻よりも後の場合は表示しない
- frontmatter の部分を htmlString から外して個別に渡す
- title を渡す
  - frontmatter の title がタイトルになる
    - なければ path の最後の '/' 移行の文字列がタイトルになる

## スクリーンショット
![image](https://github.com/weseek/growi-training-camp2023-e/assets/58359526/043e9ab9-c5d0-4faa-9ca8-df344232843f)
