### PR TITLE
Feat/69-add-title

### DIFF
--- a/apps/mobliz-clone/src/pages/[pageId].tsx
+++ b/apps/mobliz-clone/src/pages/[pageId].tsx
@@ -14,13 +14,14 @@ const DetailPage: NextPage<Props> = (props: Props) => {
   const router = useRouter();
   const pageId = router.query.pageId ?? props.pageId;
   const [htmlString, setHTMLString] = useState();
+  const [title, setTitle] = useState();
   const [error, setError] = useState<string>();
 
   useEffect(() => {
     axios.get(`${process.env.NEXT_PUBLIC_APP_SITE_URL}/_cms/${pageId}.json`)
       .then((response) => {
-        console.log(response);
         setHTMLString(response.data.htmlString);
+        setTitle(response.data.title);
       })
       .catch((error) => {
         setError(`データの取得に失敗しました。\n${JSON.stringify(error)}`);
@@ -36,7 +37,10 @@ const DetailPage: NextPage<Props> = (props: Props) => {
               <span className="visually-hidden">Loading...</span>
             </div>
           ) : (
-            <>{parse(htmlString)}</>
+            <>
+              <h2 className="pb-5 fw-bold">{title}</h2>
+              {parse(htmlString)}
+            </>
           )}
         </>
       ) : (

--- a/apps/mobliz-clone/src/pages/[pageId].tsx
+++ b/apps/mobliz-clone/src/pages/[pageId].tsx
@@ -13,15 +13,13 @@ type Props = {
 const DetailPage: NextPage<Props> = (props: Props) => {
   const router = useRouter();
   const pageId = router.query.pageId ?? props.pageId;
-  const [htmlString, setHTMLString] = useState();
-  const [title, setTitle] = useState();
+  const [pageData, setPageData] = useState<any>();
   const [error, setError] = useState<string>();
 
   useEffect(() => {
     axios.get(`${process.env.NEXT_PUBLIC_APP_SITE_URL}/_cms/${pageId}.json`)
       .then((response) => {
-        setHTMLString(response.data.htmlString);
-        setTitle(response.data.title);
+        setPageData(response.data);
       })
       .catch((error) => {
         setError(`データの取得に失敗しました。\n${JSON.stringify(error)}`);
@@ -32,14 +30,14 @@ const DetailPage: NextPage<Props> = (props: Props) => {
     <div className="border bg-white p-5">
       {error == null ? (
         <>
-          {htmlString == null ? (
+          {pageData == null ? (
             <div className="spinner-border" role="status">
               <span className="visually-hidden">Loading...</span>
             </div>
           ) : (
             <>
-              <h2 className="pb-5 fw-bold">{title}</h2>
-              {parse(htmlString)}
+              <h2 className="pb-5 fw-bold">{pageData.title}</h2>
+              {parse(pageData.htmlString)}
             </>
           )}
         </>

--- a/apps/mobliz-clone/src/pages/index.tsx
+++ b/apps/mobliz-clone/src/pages/index.tsx
@@ -33,6 +33,7 @@ const TopPage: NextPage = () => {
                 return (
                   <div className={`border bg-white p-5${index === 0 ? '' : ' mt-5'}`}>
                     <div className="index-preview overflow-hidden">
+                      <h2 className="pb-5 fw-bold">{pageData.title}</h2>
                       {parse(pageData.htmlString)}
                     </div>
                     <a href={`/${pageData.page._id}`} className="btn btn-outline-primary text-decoration-none rounded-0 mt-4">


### PR DESCRIPTION
一覧と詳細画面に title を追加

```
---
cms:
    title: GROWI へようこそ
    foo: bar
    foo2: bar2
    publishedAt: 2023-10-11
---
```
title 部分

#### 一覧
<img width="1193" alt="スクリーンショット 2023-10-12 22 47 13" src="https://github.com/weseek/growi-training-camp2023-e/assets/104429196/cea6b3a0-c5c3-4299-ba0b-0d421f3bbc32">

#### 詳細
<img width="1191" alt="スクリーンショット 2023-10-12 22 46 54" src="https://github.com/weseek/growi-training-camp2023-e/assets/104429196/238836bf-2b90-424c-a3e2-f565db538704">
