### PR TITLE
fix new post & tag

### DIFF
--- a/apps/mobliz-clone/src/components/SideMenu.tsx
+++ b/apps/mobliz-clone/src/components/SideMenu.tsx
@@ -44,7 +44,9 @@ const SideMenu: React.FC = () => {
                       <li className="container">
                         <div className="row">
                           <div className={`col-10 ${newPost.length - 1 === index ? '' : ' border-bottom'}`}>
-                            <p className="my-2 ml-5">{`${newPostData.title}`}</p>
+                            <a href={`/${newPostData.page._id}`} className="new-post-list text-decoration-none">
+                              <p className="my-2 ml-5">{`${newPostData.title}`}</p>
+                            </a>
                           </div>
                         </div>
                       </li>

--- a/apps/mobliz-clone/src/components/SideMenu.tsx
+++ b/apps/mobliz-clone/src/components/SideMenu.tsx
@@ -3,13 +3,24 @@ import React, { useState, useEffect } from 'react';
 import axios from '~/utils/axios';
 
 const SideMenu: React.FC = () => {
-  const [data, setData] = useState<any[]>();
+  const [tag, setTag] = useState<any[]>();
+  const [newPost, setNewPost] = useState<any[]>();
   const [error, setError] = useState<string>();
 
   useEffect(() => {
     axios.get(`${process.env.NEXT_PUBLIC_APP_SITE_URL}/_cms/tags`)
       .then((response) => {
-        setData(response.data.data);
+        setTag(response.data.data);
+      })
+      .catch((error) => {
+        setError(`データの取得に失敗しました。\n${JSON.stringify(error)}`);
+      });
+  }, []);
+
+  useEffect(() => {
+    axios.get(`${process.env.NEXT_PUBLIC_APP_SITE_URL}/_cms/list.json`)
+      .then((response) => {
+        setNewPost(response.data);
       })
       .catch((error) => {
         setError(`データの取得に失敗しました。\n${JSON.stringify(error)}`);
@@ -19,24 +30,37 @@ const SideMenu: React.FC = () => {
     <>
       {error == null ? (
         <>
-          {data == null ? (
+          {tag == null || newPost == null ? (
             <div className="spinner-border" role="status">
               <span className="visually-hidden">Loading...</span>
             </div>
           ) : (
             <>
               <div>
-                <p>最新記事</p>
+                <div>最新記事</div>
+                <ul className="p-2">
+                  {newPost.map((newPostData, index) => {
+                    return (
+                      <li className="container">
+                        <div className="row">
+                          <div className={`col-10 ${newPost.length - 1 === index ? '' : ' border-bottom'}`}>
+                            <p className="my-2 ml-5">{`${newPostData.title}`}</p>
+                          </div>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
               </div>
               <div>
                 <div>タグ</div>
                 <ul className="p-2">
-                  {data.map((pageData, index) => {
+                  {tag.map((tagData, index) => {
                     return (
                       <li className="container">
                         <div className="row">
-                          <div className={`col-8 ${index === 0 ? ' border-bottom' : ''}`}>
-                            <p className="my-2 ml-5">{`${pageData.name}`}</p>
+                          <div className={`col-10 ${tag.length - 1 === index ? '' : ' border-bottom'}`}>
+                            <p className="my-2 ml-5">{`${tagData.name}`}</p>
                           </div>
                         </div>
                       </li>

--- a/apps/mobliz-clone/src/pages/index.tsx
+++ b/apps/mobliz-clone/src/pages/index.tsx
@@ -33,7 +33,9 @@ const TopPage: NextPage = () => {
                 return (
                   <div className={`border bg-white p-5${index === 0 ? '' : ' mt-5'}`}>
                     <div className="index-preview overflow-hidden">
-                      <h2 className="pb-5 fw-bold">{pageData.title}</h2>
+                      <a href={`/${pageData.page._id}`} className="post-title text-decoration-none">
+                        <h2 className="post-title mb-5 fw-bold">{pageData.title}</h2>
+                      </a>
                       {parse(pageData.htmlString)}
                     </div>
                     <a href={`/${pageData.page._id}`} className="btn btn-outline-primary text-decoration-none rounded-0 mt-4">

--- a/apps/mobliz-clone/src/styles/globals.scss
+++ b/apps/mobliz-clone/src/styles/globals.scss
@@ -36,3 +36,17 @@ img {
 .index-preview {
   max-height: 500px;
 }
+
+.post-title {
+  color: #383838;
+  &:hover {
+    color: #f24e4f;
+  }
+}
+
+.new-post-list {
+  color: #383838;
+  &:hover {
+    color: #2581c4;
+  }
+}


### PR DESCRIPTION
- 最新記事部分に title を表示
- 最新記事とタグ のボーダーラインをつける条件を変更

<img width="1227" alt="スクリーンショット 2023-10-13 4 38 10" src="https://github.com/weseek/growi-training-camp2023-e/assets/104429196/fc649807-9e0a-4b2d-b748-61eb6958aa7f">

### hover 時
<img width="703" alt="スクリーンショット 2023-10-13 10 46 55" src="https://github.com/weseek/growi-training-camp2023-e/assets/104429196/9a6e263c-f3b1-487b-9f67-8dc54b29ba79">
<img width="459" alt="スクリーンショット 2023-10-13 10 47 02" src="https://github.com/weseek/growi-training-camp2023-e/assets/104429196/1691e1a6-ac94-42f6-a945-d7363ea047db">
