### PR TITLE
Feat/tc2023e-23 add items to article page

### DIFF
--- a/apps/mobliz-clone/src/pages/[pageId].tsx
+++ b/apps/mobliz-clone/src/pages/[pageId].tsx
@@ -14,13 +14,13 @@ type Props = {
 const DetailPage: NextPage<Props> = (props: Props) => {
   const router = useRouter();
   const pageId = router.query.pageId ?? props.pageId;
-  const [pageData, setPageData] = useState<any>();
+  const [resData, setRresData] = useState<any>();
   const [error, setError] = useState<string>();
 
   useEffect(() => {
     axios.get(`${process.env.NEXT_PUBLIC_APP_SITE_URL}/_cms/${pageId}.json`)
       .then((response) => {
-        setPageData(response.data);
+        setRresData(response.data);
       })
       .catch((error) => {
         setError(`データの取得に失敗しました。\n${JSON.stringify(error)}`);
@@ -31,21 +31,21 @@ const DetailPage: NextPage<Props> = (props: Props) => {
     <div className="border bg-white p-5">
       {error == null ? (
         <>
-          {pageData == null ? (
+          {resData == null ? (
             <div className="spinner-border" role="status">
               <span className="visually-hidden">Loading...</span>
             </div>
           ) : (
             <>
               <div className="list-inline d-flex mb-4">
-                <p className="me-4"> {dateFnsFormat(new Date(pageData.page.createdAt), 'yyyy.MM.dd')}</p>
-                <div> {dateFnsFormat(new Date(pageData.page.updatedAt), 'yyyy.MM.dd')}</div>
+                <p className="me-4"> {dateFnsFormat(new Date(resData.page.createdAt), 'yyyy.MM.dd')}</p>
+                <div> {dateFnsFormat(new Date(resData.page.updatedAt), 'yyyy.MM.dd')}</div>
               </div>
-              <h2 className="pb-5 fw-bold">{pageData.title}</h2>
-              {parse(pageData.htmlString)}
+              <h2 className="pb-5 fw-bold">{resData.title}</h2>
+              {parse(resData.htmlString)}
               <hr />
-              <img src={pageData.page.creator.imageUrlCached} width="100" height="100" alt="" />
-              <p><strong>{pageData.page.creator.name}</strong></p>
+              <img src={resData.page.creator.imageUrlCached} width="100" height="100" alt="" />
+              <p><strong>{resData.page.creator.name}</strong></p>
             </>
           )}
         </>

--- a/apps/mobliz-clone/src/pages/[pageId].tsx
+++ b/apps/mobliz-clone/src/pages/[pageId].tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
+import dateFnsFormat from 'date-fns/format';
 import parse from 'html-react-parser';
 import { NextPage, GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
@@ -36,8 +37,15 @@ const DetailPage: NextPage<Props> = (props: Props) => {
             </div>
           ) : (
             <>
+              <div className="list-inline d-flex mb-4">
+                <p className="me-4"> {dateFnsFormat(new Date(pageData.page.createdAt), 'yyyy.MM.dd')}</p>
+                <div> {dateFnsFormat(new Date(pageData.page.updatedAt), 'yyyy.MM.dd')}</div>
+              </div>
               <h2 className="pb-5 fw-bold">{pageData.title}</h2>
               {parse(pageData.htmlString)}
+              <hr />
+              <img src={pageData.page.creator.imageUrlCached} width="100" height="100" alt="" />
+              <p><strong>{pageData.page.creator.name}</strong></p>
             </>
           )}
         </>

--- a/apps/mobliz-clone/src/pages/[pageId].tsx
+++ b/apps/mobliz-clone/src/pages/[pageId].tsx
@@ -38,8 +38,8 @@ const DetailPage: NextPage<Props> = (props: Props) => {
           ) : (
             <>
               <div className="list-inline d-flex mb-4">
-                <p className="me-4"> {dateFnsFormat(new Date(resData.page.createdAt), 'yyyy.MM.dd')}</p>
-                <div> {dateFnsFormat(new Date(resData.page.updatedAt), 'yyyy.MM.dd')}</div>
+                <p className="me-4">{dateFnsFormat(new Date(resData.page.createdAt), 'yyyy.MM.dd')}</p>
+                <p>{dateFnsFormat(new Date(resData.page.updatedAt), 'yyyy.MM.dd')}</p>
               </div>
               <h2 className="pb-5 fw-bold">{resData.title}</h2>
               {parse(resData.htmlString)}

--- a/apps/mobliz-clone/src/pages/[pageId].tsx
+++ b/apps/mobliz-clone/src/pages/[pageId].tsx
@@ -14,13 +14,13 @@ type Props = {
 const DetailPage: NextPage<Props> = (props: Props) => {
   const router = useRouter();
   const pageId = router.query.pageId ?? props.pageId;
-  const [resData, setRresData] = useState<any>();
+  const [resData, setResData] = useState<any>();
   const [error, setError] = useState<string>();
 
   useEffect(() => {
     axios.get(`${process.env.NEXT_PUBLIC_APP_SITE_URL}/_cms/${pageId}.json`)
       .then((response) => {
-        setRresData(response.data);
+        setResData(response.data);
       })
       .catch((error) => {
         setError(`データの取得に失敗しました。\n${JSON.stringify(error)}`);

--- a/apps/mobliz-clone/src/pages/index.tsx
+++ b/apps/mobliz-clone/src/pages/index.tsx
@@ -34,8 +34,8 @@ const TopPage: NextPage = () => {
                 return (
                   <div className={`border bg-white p-5${index === 0 ? '' : ' mt-5'}`}>
                     <div className="list-inline d-flex mb-4">
-                      <p className="me-4"> {dateFnsFormat(new Date(data.page.createdAt), 'yyyy.MM.dd')}</p>
-                      <div> {dateFnsFormat(new Date(data.page.updatedAt), 'yyyy.MM.dd')}</div>
+                      <p className="me-4">{dateFnsFormat(new Date(data.page.createdAt), 'yyyy.MM.dd')}</p>
+                      <p>{dateFnsFormat(new Date(data.page.updatedAt), 'yyyy.MM.dd')}</p>
                     </div>
                     <div className="index-preview overflow-hidden">
                       <a href={`/${data.page._id}`} className="post-title text-decoration-none">

--- a/apps/mobliz-clone/src/pages/index.tsx
+++ b/apps/mobliz-clone/src/pages/index.tsx
@@ -7,13 +7,13 @@ import { NextPage } from 'next';
 import axios from '~/utils/axios';
 
 const TopPage: NextPage = () => {
-  const [data, setData] = useState<any[]>();
+  const [resData, setResData] = useState<any[]>();
   const [error, setError] = useState<string>();
 
   useEffect(() => {
     axios.get(`${process.env.NEXT_PUBLIC_APP_SITE_URL}/_cms/list.json`)
       .then((response) => {
-        setData(response.data);
+        setResData(response.data);
       })
       .catch((error) => {
         setError(`データの取得に失敗しました。\n${JSON.stringify(error)}`);
@@ -24,24 +24,24 @@ const TopPage: NextPage = () => {
     <>
       {error == null ? (
         <>
-          {data == null ? (
+          {resData == null ? (
             <div className="spinner-border" role="status">
               <span className="visually-hidden">Loading...</span>
             </div>
           ) : (
             <>
-              {data.map((pageData, index) => {
+              {resData.map((data, index) => {
                 return (
                   <div className={`border bg-white p-5${index === 0 ? '' : ' mt-5'}`}>
                     <div className="list-inline d-flex mb-4">
-                      <p className="me-4"> {dateFnsFormat(new Date(pageData.page.createdAt), 'yyyy.MM.dd')}</p>
-                      <div> {dateFnsFormat(new Date(pageData.page.updatedAt), 'yyyy.MM.dd')}</div>
+                      <p className="me-4"> {dateFnsFormat(new Date(data.page.createdAt), 'yyyy.MM.dd')}</p>
+                      <div> {dateFnsFormat(new Date(data.page.updatedAt), 'yyyy.MM.dd')}</div>
                     </div>
                     <div className="index-preview overflow-hidden">
-                      <h2 className="pb-5 fw-bold">{pageData.title}</h2>
-                      {parse(pageData.htmlString)}
+                      <h2 className="pb-5 fw-bold">{data.title}</h2>
+                      {parse(data.htmlString)}
                     </div>
-                    <a href={`/${pageData.page._id}`} className="btn btn-outline-primary text-decoration-none rounded-0 mt-4">
+                    <a href={`/${data.page._id}`} className="btn btn-outline-primary text-decoration-none rounded-0 mt-4">
                       続きを読む
                     </a>
                   </div>

--- a/apps/mobliz-clone/src/pages/index.tsx
+++ b/apps/mobliz-clone/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
+import dateFnsFormat from 'date-fns/format';
 import parse from 'html-react-parser';
 import { NextPage } from 'next';
 
@@ -32,6 +33,10 @@ const TopPage: NextPage = () => {
               {data.map((pageData, index) => {
                 return (
                   <div className={`border bg-white p-5${index === 0 ? '' : ' mt-5'}`}>
+                    <div className="list-inline d-flex mb-4">
+                      <p className="me-4"> {dateFnsFormat(new Date(pageData.page.createdAt), 'yyyy.MM.dd')}</p>
+                      <div> {dateFnsFormat(new Date(pageData.page.updatedAt), 'yyyy.MM.dd')}</div>
+                    </div>
                     <div className="index-preview overflow-hidden">
                       <h2 className="pb-5 fw-bold">{pageData.title}</h2>
                       {parse(pageData.htmlString)}


### PR DESCRIPTION
やったこと
- 記事一覧・詳細ページにcreatedAt, updatedAtを追加
- 詳細ページに投稿者名・ユーザーアイコン追加

一覧ページ
![一覧ページ](https://github.com/weseek/growi-training-camp2023-e/assets/69101210/8439234e-8b1a-4624-885e-102e5eded7e8)

詳細ページ
![詳細ページ](https://github.com/weseek/growi-training-camp2023-e/assets/69101210/5e18b705-7b7b-460d-8ed4-e7166f62a132)
